### PR TITLE
feat: Version, build and release go apps

### DIFF
--- a/.github/workflows/build-and-release-go.yml
+++ b/.github/workflows/build-and-release-go.yml
@@ -16,6 +16,9 @@ on:
         type: string
         default: 'main.go'
 
+permissions:
+  contents: write
+
 jobs:
   version:
     uses: LarsNieuwenhuizen/workflows/.github/workflows/define-version.yml@feat/go-build-release-workflow

--- a/.github/workflows/build-and-release-go.yml
+++ b/.github/workflows/build-and-release-go.yml
@@ -3,15 +3,86 @@ name: Build and release Go code
 on:
   workflow_call:
     inputs:
-      name:
+      app-name:
         required: false
         type: string
-        default: 'go-project'
+        default: 'app'
       go-version:
         required: false
         type: string
         default: '1.23'
+      build-file:
+        required: false
+        type: string
+        default: 'main.go'
 
 jobs:
   version:
     uses: LarsNieuwenhuizen/workflows/.github/workflows/define-version.yml@feat/go-build-release-workflow
+
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os-arch-combinations:
+          - arch: amd64
+            os: linux
+          - arch: arm64
+            os: linux
+          - arch: arm
+            os: linux
+          - arch: amd64
+            os: darwin
+          - arch: arm64
+            os: darwin
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go ${{ inputs.go-version }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ inputs.go-version }}
+        id: go
+
+      - name: Build
+        shell: bash
+        run: |
+          GOOS=${{ matrix.os-arch-combinations.os }} GOARCH=${{ matrix.os-arch-combinations.arch }} go build --ldflags '-extldflags "-static"' -o bin/${{ inputs.app-name }} ${{ inputs.build-file }}
+          cd bin
+          tar -czvf "${{ inputs.app-name }}-${{ matrix.os-arch-combinations.os }}-${{ matrix.os-arch-combinations.arch }}.tar.gz" ${{ inputs.app-name }}
+          rm ${{ inputs.app-name }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build-artifact-${{ matrix.os-arch-combinations.os }}-${{ matrix.os-arch-combinations.arch }}
+          path: bin/*.tar.gz
+          retention-days: 1
+
+  release:
+    runs-on: ubuntu-latest
+    needs:
+      - version
+      - build
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/download-artifact@v4
+      with:
+        path: bin
+        merge-multiple: true
+
+    - name: Check the created tarballs
+      shell: bash
+      run: |
+        ls -al bin
+
+    - name: Create a release commit
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        git config user.name "GitHub Actions"
+        git config user.email "no-reply@email.com"
+        git commit -m "release: ${{ needs.version.outputs.release_version }}" --allow-empty
+        git push origin main --tags
+        gh release create ${{ needs.version.outputs.release_version }} ./bin/*.tar.gz --generate-notes

--- a/.github/workflows/build-and-release-go.yml
+++ b/.github/workflows/build-and-release-go.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   version:
-    uses: LarsNieuwenhuizen/workflows/.github/workflows/define-version.yml@main
+    uses: LarsNieuwenhuizen/workflows/.github/workflows/define-version.yml@feat/go-build-release-workflow
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-release-go.yml
+++ b/.github/workflows/build-and-release-go.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   version:
-    uses: LarsNieuwenhuizen/workflows/.github/workflows/define-version.yml@feat/go-build-release-workflow
+    uses: LarsNieuwenhuizen/workflows/.github/workflows/define-version.yml@main
 
   build:
     runs-on: ubuntu-latest
@@ -86,6 +86,6 @@ jobs:
       run: |
         git config user.name "GitHub Actions"
         git config user.email "no-reply@email.com"
-        git commit -m "release: ${{ needs.version.outputs.release_version }}" --allow-empty
+        git commit -m "release: ${{ needs.version.outputs.release-version }}" --allow-empty
         git push origin main --tags
-        gh release create ${{ needs.version.outputs.release_version }} ./bin/*.tar.gz --generate-notes
+        gh release create ${{ needs.version.outputs.release-version }} ./bin/*.tar.gz --generate-notes

--- a/.github/workflows/build-and-release-go.yml
+++ b/.github/workflows/build-and-release-go.yml
@@ -1,0 +1,27 @@
+name: Build and release Go code
+
+on:
+  workflow_call:
+    inputs:
+      name:
+        required: false
+        type: string
+        default: 'go-project'
+      go-version:
+        required: false
+        type: string
+        default: '1.23'
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Define version
+        id: version
+        uses: LarsNieuwenhuizen/action-define-release-version@v1

--- a/.github/workflows/build-and-release-go.yml
+++ b/.github/workflows/build-and-release-go.yml
@@ -15,6 +15,10 @@ on:
         required: false
         type: string
         default: 'main.go'
+      target-branch:
+        required: false
+        type: string
+        default: 'main'
 
 permissions:
   contents: write
@@ -87,5 +91,5 @@ jobs:
         git config user.name "GitHub Actions"
         git config user.email "no-reply@email.com"
         git commit -m "release: ${{ needs.version.outputs.release-version }}" --allow-empty
-        git push origin main --tags
+        git push origin ${{ inputs.target-branch }} --tags
         gh release create ${{ needs.version.outputs.release-version }} ./bin/*.tar.gz --generate-notes

--- a/.github/workflows/build-and-release-go.yml
+++ b/.github/workflows/build-and-release-go.yml
@@ -14,18 +14,4 @@ on:
 
 jobs:
   version:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-
-      - name: Define version
-        id: version
-        uses: LarsNieuwenhuizen/action-define-release-version@v1
-
-      - name: Use version
-        run: |
-          echo "Version: ${{ steps.version.outputs.release_version }}"
+    uses: LarsNieuwenhuizen/workflows/.github/workflows/define-version.yml@feat/go-build-release-workflow

--- a/.github/workflows/build-and-release-go.yml
+++ b/.github/workflows/build-and-release-go.yml
@@ -25,3 +25,7 @@ jobs:
       - name: Define version
         id: version
         uses: LarsNieuwenhuizen/action-define-release-version@v1
+
+      - name: Use version
+        run: |
+          echo "Version: ${{ steps.version.outputs.release_version }}"

--- a/.github/workflows/build-and-release-go.yml
+++ b/.github/workflows/build-and-release-go.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   version:
-    uses: LarsNieuwenhuizen/workflows/.github/workflows/define-version.yml@feat/go-build-release-workflow
+    uses: LarsNieuwenhuizen/workflows/.github/workflows/define-version.yml@main
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/define-version.yml
+++ b/.github/workflows/define-version.yml
@@ -22,3 +22,6 @@ jobs:
       - name: Define version
         id: version
         uses: LarsNieuwenhuizen/action-define-release-version@v1
+
+      - name: Set output
+        run: echo "release_version=${{ steps.version.outputs.release_version }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/define-version.yml
+++ b/.github/workflows/define-version.yml
@@ -3,7 +3,7 @@ name: Define next version of your application
 on:
   workflow_call:
     outputs:
-      release_version:
+      result:
         description: "The next version of your application"
         value: ${{ jobs.version.outputs.release_version }}
 

--- a/.github/workflows/define-version.yml
+++ b/.github/workflows/define-version.yml
@@ -2,10 +2,16 @@ name: Define next version of your application
 
 on:
   workflow_call:
+    outputs:
+      release_version:
+        description: "The next version of your application"
+        value: ${{ jobs.version.outputs.release_version }}
 
 jobs:
   version:
     runs-on: ubuntu-latest
+    outputs:
+      release_version: ${{ steps.version.outputs.release_version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/define-version.yml
+++ b/.github/workflows/define-version.yml
@@ -1,0 +1,18 @@
+name: Define next version of your application
+
+on:
+  workflow_call:
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Define version
+        id: version
+        uses: LarsNieuwenhuizen/action-define-release-version@v1

--- a/.github/workflows/define-version.yml
+++ b/.github/workflows/define-version.yml
@@ -3,15 +3,15 @@ name: Define next version of your application
 on:
   workflow_call:
     outputs:
-      release_version:
+      release-version:
         description: "The next version of your application"
-        value: ${{ jobs.version.outputs.release_version }}
+        value: ${{ jobs.version.outputs.release-version }}
 
 jobs:
   version:
     runs-on: ubuntu-latest
     outputs:
-      release_version: ${{ steps.result.outputs.release_version }}
+      release-version: ${{ steps.result.outputs.release-version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -25,4 +25,4 @@ jobs:
 
       - name: Set output
         id: result
-        run: echo "release_version=${{ steps.version.outputs.release_version }}" >> $GITHUB_OUTPUT
+        run: echo "release-version=${{ steps.version.outputs.release-version }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/define-version.yml
+++ b/.github/workflows/define-version.yml
@@ -11,7 +11,7 @@ jobs:
   version:
     runs-on: ubuntu-latest
     outputs:
-      release_version: ${{ steps.version.outputs.release_version }}
+      release_version: ${{ steps.result.outputs.release_version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -24,4 +24,5 @@ jobs:
         uses: LarsNieuwenhuizen/action-define-release-version@v1
 
       - name: Set output
+        id: result
         run: echo "release_version=${{ steps.version.outputs.release_version }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/define-version.yml
+++ b/.github/workflows/define-version.yml
@@ -3,7 +3,7 @@ name: Define next version of your application
 on:
   workflow_call:
     outputs:
-      result:
+      release_version:
         description: "The next version of your application"
         value: ${{ jobs.version.outputs.release_version }}
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,49 @@
 
 Here are some generic reusable workflows you can use in your projects.
 
+## Generic
+
+### Define the next version for your apps based on commits
+
+This workflow grabs the latest tag, defines the next version based on the commits after it.
+
+`LarsNieuwenhuizen/workflows/.github/workflows/define-version@main`
+
+The outputs:
+
+| Name             |  Type   | Description | Example |
+|------------------|---------|-------------|---------|
+| release-version  | string  | The next application version based on commits | v1.1.0 |
+
+Example usage:
+
+.github/workflows/version.yml
+
+```yaml
+name: My awesome workflow in which I need to define the next version of my app
+
+on:
+  workflow_dispatch:
+
+jobs:
+  version:
+    uses: LarsNieuwenhuizen/workflows/.github/workflows/define-version.yml@main
+
+  use-version:
+    needs: version
+    steps:
+    - name: Echo the version
+      run: |
+        echo "${{ needs.version.outputs.release-version }}"
+```
+
 ## Golang
 
 ### Testing your code
 
 Test you go code with the test-go.yml workflow.
+
+`LarsNieuwenhuizen/workflows/.github/workflows/test-go.yml@main`
 
 The inputs
 
@@ -19,7 +57,9 @@ The inputs
 Example usage:
 
 .github/workflows/test.yml
+
 ---
+
 ```yaml
 name: Testing Go code
 
@@ -42,4 +82,42 @@ jobs:
       with:
         path: "github.com/username/my-application/pkg/example"
         name: "Example"
+```
+
+### Building and releasing Go applications
+
+Build and create a release your Go app
+
+> [!IMPORTANT]
+> This workflow creates a release in your Github repository, so it needs write permissions.
+> Do not forget to add this in your workflow!
+> Check the example -> permissions.contents = write
+
+The inputs
+
+| Name         | Required | Type   | Default    | Description                              |
+|--------------|----------|--------|------------|------------------------------------------|
+| app-name     | no       | string | app        | The name of your application binary that will be created |
+| go-version   | no       | string | 1.23       | The Golang version to use                |
+| build-file   | no       | string | main.go    | The default file which will be used in the build command |
+
+Example usage:
+
+.github/workflows/build-release.yml
+
+```yaml
+name: Build and Release
+
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions:
+  contents: write
+
+jobs:
+  build-release:
+    if: github.event.pull_request.merged == true
+    uses: LarsNieuwenhuizen/workflows/.github/workflows/build-and-release-go.yml@feat/go-build-release-workflow
 ```


### PR DESCRIPTION
This pull request introduces two new reusable workflows for versioning and building/releasing Go applications, along with documentation updates to the `README.md` to explain their usage. The workflows streamline the process of defining application versions and automating builds/releases for Go projects.

### New reusable workflows:

* [`.github/workflows/define-version.yml`](diffhunk://#diff-dbea212477572b141d8602b10fe4d1103b6d6e62cc390653dc56eb671791c477R1-R28): Adds a workflow to define the next version of an application based on commit history and tags. Outputs the next version as `release-version`.
* [`.github/workflows/build-and-release-go.yml`](diffhunk://#diff-14cb08c1399e5ebec9f88f580f8f1aa1837e3e6744114f516bc166fc9ef03181R1-R91): Implements a workflow for building and releasing Go applications, supporting multiple OS and architecture combinations. Includes artifact upload and automated release creation.

### Documentation updates:

* `README.md`: Adds sections to explain the usage of the new workflows, including detailed descriptions of inputs, outputs, and example configurations:
  - **Define Version Workflow**: Explains how to use the `define-version.yml` workflow to determine the next application version.
  - **Build and Release Workflow**: Details how to use the `build-and-release-go.yml` workflow for building and releasing Go applications, including required permissions and example usage.